### PR TITLE
Translate interface to Spanish

### DIFF
--- a/frontend/src/components/menu/AddCategoryDialog.tsx
+++ b/frontend/src/components/menu/AddCategoryDialog.tsx
@@ -40,11 +40,11 @@ const AddCategoryDialog: React.FC<Props> = ({ open, onOpenChange, existingCatego
     const formatted = toTitleCase(name.trim());
 
     if (!formatted) {
-      toast({ title: "Category name is required", variant: "destructive" });
+      toast({ title: "Se requiere nombre de categoría", variant: "destructive" });
       return;
     }
     if (existingCategories.includes(formatted.toLowerCase())) {
-      toast({ title: "Category already exists", variant: "destructive" });
+      toast({ title: "La categoría ya existe", variant: "destructive" });
       return;
     }
 
@@ -59,13 +59,13 @@ const AddCategoryDialog: React.FC<Props> = ({ open, onOpenChange, existingCatego
         console.error("Failed to create default subcategory", err);
       }
 
-      toast({ title: "Category created" });
+      toast({ title: "Categoría creada" });
       onCreated();
       reset();
       onOpenChange(false);
     } catch (error) {
       console.error(error);
-      toast({ title: "Failed to create category", variant: "destructive" });
+      toast({ title: "Error al crear la categoría", variant: "destructive" });
     }
   };
 
@@ -73,15 +73,15 @@ const AddCategoryDialog: React.FC<Props> = ({ open, onOpenChange, existingCatego
     <Dialog open={open} onOpenChange={(o)=>{ if(!o) reset(); onOpenChange(o);} }>
       <DialogContent className="sm:max-w-[400px]">
         <DialogHeader>
-          <DialogTitle>Create Category</DialogTitle>
+          <DialogTitle>Crear Categoría</DialogTitle>
           <DialogDescription>
-            Enter a unique name for the new menu category.
+            Ingresa un nombre único para la nueva categoría del menú.
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">
           <div className="grid grid-cols-4 items-center gap-4">
             <Label htmlFor="category-name" className="text-right">
-              Name
+              Nombre
             </Label>
             <Input
               id="category-name"
@@ -94,9 +94,9 @@ const AddCategoryDialog: React.FC<Props> = ({ open, onOpenChange, existingCatego
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={()=>onOpenChange(false)}>
-            Cancel
+            Cancelar
           </Button>
-          <Button onClick={handleCreate}>Create</Button>
+          <Button onClick={handleCreate}>Crear</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/menu/AddSubcategoryDialog.tsx
+++ b/frontend/src/components/menu/AddSubcategoryDialog.tsx
@@ -32,32 +32,32 @@ const AddSubcategoryDialog: React.FC<Props> = ({ open, onOpenChange, categoryId,
 
   const handleCreate = async () => {
     const formatted = toTitle(name);
-    if (!formatted) { toast({title:"Name required",variant:"destructive"}); return; }
-    if (existingNames.includes(formatted.toLowerCase())) { toast({title:"Exists",variant:"destructive"}); return; }
+    if (!formatted) { toast({title:"Nombre requerido",variant:"destructive"}); return; }
+    if (existingNames.includes(formatted.toLowerCase())) { toast({title:"Ya existe",variant:"destructive"}); return; }
     try {
       await createSubcategory({ name: formatted, category_id: categoryId });
-      toast({title:"Subcategory created"});
+      toast({title:"Subcategoría creada"});
       onCreated();
       resetClose();
-    } catch(e){ console.error(e); toast({title:"Failed",variant:"destructive"}); }
+    } catch(e){ console.error(e); toast({title:"Error",variant:"destructive"}); }
   };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[400px]">
         <DialogHeader>
-          <DialogTitle>Add Subcategory</DialogTitle>
-          <DialogDescription>Enter subcategory name.</DialogDescription>
+          <DialogTitle>Agregar Subcategoría</DialogTitle>
+          <DialogDescription>Ingresa el nombre de la subcategoría.</DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">
           <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="sub-name" className="text-right">Name</Label>
+            <Label htmlFor="sub-name" className="text-right">Nombre</Label>
             <Input id="sub-name" value={name} onChange={(e)=>setName(e.target.value)} className="col-span-3" />
           </div>
         </div>
         <DialogFooter>
-          <Button variant="outline" onClick={()=>onOpenChange(false)}>Cancel</Button>
-          <Button onClick={handleCreate}>Create</Button>
+          <Button variant="outline" onClick={()=>onOpenChange(false)}>Cancelar</Button>
+          <Button onClick={handleCreate}>Crear</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/menu/EditCategoriesDialog.tsx
+++ b/frontend/src/components/menu/EditCategoriesDialog.tsx
@@ -80,7 +80,7 @@ const EditCategoriesDialog: React.FC<Props> = ({ open, onOpenChange, categories,
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
-          <DialogTitle>Edit Categories</DialogTitle>
+          <DialogTitle>Editar Categorías</DialogTitle>
         </DialogHeader>
         <div className="space-y-3 max-h-60 overflow-y-auto">
           {localCats.map((cat) => (
@@ -109,7 +109,7 @@ const EditCategoriesDialog: React.FC<Props> = ({ open, onOpenChange, categories,
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Close
+            Cerrar
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -118,15 +118,15 @@ const EditCategoriesDialog: React.FC<Props> = ({ open, onOpenChange, categories,
       <AlertDialog open={!!deleteTarget} onOpenChange={(o) => !o && setDeleteTarget(null)}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete category?</AlertDialogTitle>
+            <AlertDialogTitle>¿Eliminar categoría?</AlertDialogTitle>
             <AlertDialogDescription>
-              This will delete the category and all menu items linked to it. This action cannot be undone.
+              Esto eliminará la categoría y todos los productos vinculados. Esta acción no se puede deshacer.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
             <AlertDialogAction onClick={confirmDelete} className="bg-red-600 hover:bg-red-700">
-              Delete
+              Eliminar
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/pages/Employees.tsx
+++ b/frontend/src/pages/Employees.tsx
@@ -47,8 +47,8 @@ const ActiveEmployees: React.FC<EmployeesSubProps> = ({ onEdit }) => {
       queryClient.invalidateQueries({ queryKey: ["employees"] });
       
       toast({
-        title: "Clock Out",
-        description: "Employee has been clocked out successfully",
+        title: "Salida",
+        description: "El empleado ha cerrado su turno exitosamente",
       });
     } catch (error) {
       console.error(error);
@@ -168,12 +168,12 @@ const ActiveEmployees: React.FC<EmployeesSubProps> = ({ onEdit }) => {
                       >
                         <Pencil className="h-4 w-4" />
                       </Button>
-                      <Button 
-                        size="sm" 
-                        variant="destructive" 
+                      <Button
+                        size="sm"
+                        variant="destructive"
                         onClick={() => handleClockOut(employee.id)}
                       >
-                        Clock Out
+                        Salida
                       </Button>
                     </TableCell>
                   </TableRow>
@@ -213,8 +213,8 @@ const InactiveEmployees: React.FC<EmployeesSubProps> = ({ onEdit }) => {
       queryClient.invalidateQueries({ queryKey: ["employees"] });
       
       toast({
-        title: "Clock In",
-        description: "Employee has been clocked in successfully",
+        title: "Entrada",
+        description: "El empleado ha iniciado su turno correctamente",
       });
     } catch (error) {
       console.error(error);
@@ -270,11 +270,11 @@ const InactiveEmployees: React.FC<EmployeesSubProps> = ({ onEdit }) => {
                       >
                         <Pencil className="h-4 w-4" />
                       </Button>
-                      <Button 
+                      <Button
                         size="sm"
                         onClick={() => handleClockIn(employee.id)}
                       >
-                        Clock In
+                        Entrada
                       </Button>
                     </TableCell>
                   </TableRow>

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -84,8 +84,8 @@ const InventoryList = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['inventoryItems'] });
       toast({
-        title: t("Product added"),
-        description: t("The product has been added to the inventory"),
+        title: t("Producto agregado"),
+        description: t("El producto se agregó al inventario"),
       });
       setIsAddDialogOpen(false);
       // Reset form
@@ -100,7 +100,7 @@ const InventoryList = () => {
     onError: (error) => {
       toast({
         title: t("Error"),
-        description: (error as Error).message || t("Could not add the product"),
+        description: (error as Error).message || t("No se pudo agregar el producto"),
         variant: "destructive"
       });
     }
@@ -113,8 +113,8 @@ const InventoryList = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['inventoryItems'] });
       toast({
-        title: t("Product updated"),
-        description: t("The product has been updated successfully"),
+        title: t("Producto actualizado"),
+        description: t("El producto se actualizó correctamente"),
       });
       setIsEditDialogOpen(false);
       setEditingItem(null);
@@ -122,7 +122,7 @@ const InventoryList = () => {
     onError: (error) => {
       toast({
         title: t("Error"),
-        description: (error as Error).message || t("Could not update the product"),
+        description: (error as Error).message || t("No se pudo actualizar el producto"),
         variant: "destructive"
       });
     }
@@ -141,7 +141,7 @@ const InventoryList = () => {
     onError: (error) => {
       toast({
         title: t("Error"),
-        description: (error as Error).message || t("Could not delete the product"),
+        description: (error as Error).message || t("No se pudo eliminar el producto"),
         variant: "destructive"
       });
     }
@@ -189,7 +189,7 @@ const InventoryList = () => {
         <AlertCircle className="h-4 w-4" />
         <AlertTitle>{t("Error")}</AlertTitle>
         <AlertDescription>
-          {(error as Error).message || t("Could not load inventory")}
+          {(error as Error).message || t("No se pudo cargar el inventario")}
         </AlertDescription>
       </Alert>
     );
@@ -206,7 +206,7 @@ const InventoryList = () => {
             size={isMobile ? "sm" : "default"}
           >
             <Plus className="h-4 w-4" />
-            {t("Add Product")}
+            {t("Agregar Producto")}
           </Button>
         </CardHeader>
         <CardContent className="px-2 sm:px-6 overflow-auto">
@@ -286,9 +286,9 @@ const InventoryList = () => {
       <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
         <DialogContent className="sm:max-w-[500px]">
           <DialogHeader>
-            <DialogTitle>{t("Add Product")}</DialogTitle>
+            <DialogTitle>{t("Agregar Producto")}</DialogTitle>
             <DialogDescription>
-              {t("Enter product information to add it to inventory.")}
+              {t("Ingresa la información del producto para añadirlo al inventario.")}
             </DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
@@ -364,10 +364,10 @@ const InventoryList = () => {
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setIsAddDialogOpen(false)}>
-              {t("Cancel")}
+              {t("Cancelar")}
             </Button>
             <Button onClick={handleAddProduct} disabled={addItemMutation.isPending}>
-              {addItemMutation.isPending ? t("Saving...") : t("Save")}
+              {addItemMutation.isPending ? t("Guardando...") : t("Guardar")}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -451,10 +451,10 @@ const InventoryList = () => {
           )}
           <DialogFooter>
             <Button variant="outline" onClick={() => setIsEditDialogOpen(false)}>
-              {t("Cancel")}
+              {t("Cancelar")}
             </Button>
             <Button onClick={handleEditProduct} disabled={updateItemMutation.isPending}>
-              {updateItemMutation.isPending ? t("Saving...") : t("Save")}
+              {updateItemMutation.isPending ? t("Guardando...") : t("Guardar")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/pages/Menu.tsx
+++ b/frontend/src/pages/Menu.tsx
@@ -156,8 +156,8 @@ const MenuSection = ({ title, items, setItems, categoryKey, subcategories, refre
       await updateItemCustomizations(created.id, { groups: newCustoms });
       
       toast({
-        title: t("Product added"),
-        description: t("The product has been added to the menu"),
+        title: t("Producto agregado"),
+        description: t("El producto ha sido agregado al menú"),
       });
       
       setIsAddDialogOpen(false);
@@ -175,7 +175,7 @@ const MenuSection = ({ title, items, setItems, categoryKey, subcategories, refre
       console.error("Error adding menu item:", error);
       toast({
         title: t("Error"),
-        description: t("Failed to add the product. Please try again."),
+        description: t("No se pudo agregar el producto. Intenta nuevamente."),
         variant: "destructive"
       });
     }
@@ -196,8 +196,8 @@ const MenuSection = ({ title, items, setItems, categoryKey, subcategories, refre
         await updateItemCustomizations(editingItem.id, { groups: editCustoms });
         
         toast({
-          title: t("Product updated"),
-          description: t("The product has been updated successfully"),
+          title: t("Producto actualizado"),
+          description: t("El producto se actualizó correctamente"),
         });
         
         setIsEditDialogOpen(false);
@@ -207,7 +207,7 @@ const MenuSection = ({ title, items, setItems, categoryKey, subcategories, refre
         console.error("Error updating menu item:", error);
         toast({
           title: t("Error"),
-          description: t("Failed to update the product. Please try again."),
+          description: t("No se pudo actualizar el producto. Intenta nuevamente."),
           variant: "destructive"
         });
       }
@@ -255,10 +255,10 @@ const MenuSection = ({ title, items, setItems, categoryKey, subcategories, refre
         <h3 className="text-xl font-medium">{title}</h3>
         <div className="flex gap-2">
           <Button variant="secondary" size="sm" onClick={() => setAddSubOpen(true)}>
-            <Plus className="h-4 w-4 mr-1" /> {t("Add Subcategory")}
+            <Plus className="h-4 w-4 mr-1" /> {t("Agregar Subcategoría")}
           </Button>
           <Button size="sm" onClick={handleAddButtonClick}>
-            <Plus className="h-4 w-4 mr-1" /> {t("Add Product")}
+            <Plus className="h-4 w-4 mr-1" /> {t("Agregar Producto")}
           </Button>
         </div>
       </div>
@@ -316,9 +316,9 @@ const MenuSection = ({ title, items, setItems, categoryKey, subcategories, refre
       <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
         <DialogContent className="sm:max-w-[600px] p-0 flex flex-col max-h-[80vh]">
           <DialogHeader className="p-4 pb-2">
-            <DialogTitle>{t("Add Product")}</DialogTitle>
+            <DialogTitle>{t("Agregar Producto")}</DialogTitle>
             <DialogDescription>
-              {t("Enter the product information to add it to the menu.")}
+              {t("Ingresa la información del producto para agregarlo al menú.")}
             </DialogDescription>
           </DialogHeader>
           <div className="max-h-[80vh] overflow-y-auto p-4 flex flex-col gap-4">
@@ -453,10 +453,10 @@ const MenuSection = ({ title, items, setItems, categoryKey, subcategories, refre
           </div>
           <DialogFooter className="p-4 pt-2">
             <Button variant="outline" onClick={() => setIsAddDialogOpen(false)}>
-              {t("Cancel")}
+              {t("Cancelar")}
             </Button>
             <Button onClick={handleAddItem}>
-              {t("Save")}
+              {t("Guardar")}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -613,10 +613,10 @@ const MenuSection = ({ title, items, setItems, categoryKey, subcategories, refre
           )}
           <DialogFooter className="p-4 pt-2">
             <Button variant="outline" onClick={() => setIsEditDialogOpen(false)}>
-              {t("Cancel")}
+              {t("Cancelar")}
             </Button>
             <Button onClick={handleEditItem}>
-              {t("Save")}
+              {t("Guardar")}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -682,7 +682,7 @@ const Menu = () => {
   return (
     <MainLayout>
       <div className="max-w-5xl mx-auto">
-        <h1 className="text-3xl font-bold mb-6">{t("Menu Management")}</h1>
+        <h1 className="text-3xl font-bold mb-6">{t("Gestión del Menú")}</h1>
         
         {loading ? (
           <div className="flex justify-center items-center h-64">
@@ -708,10 +708,10 @@ const Menu = () => {
                   </DropdownMenuTrigger>
                   <DropdownMenuContent>
                     <DropdownMenuItem onSelect={() => setAddCatOpen(true)}>
-                      Add Category
+                      Agregar Categoría
                     </DropdownMenuItem>
                     <DropdownMenuItem onSelect={() => setEditCatOpen(true)}>
-                      Edit Categories
+                      Editar Categorías
                     </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>

--- a/frontend/src/pages/Tables.tsx
+++ b/frontend/src/pages/Tables.tsx
@@ -35,10 +35,10 @@ const statusColors: Record<TableStatus, string> = {
 };
 
 const statusLabels: Record<TableStatus, string> = {
-  available: "Available",
-  pending: "Pending",
-  occupied: "Occupied",
-  reserved: "Reserved"
+  available: "Disponible",
+  pending: "Pendiente",
+  occupied: "Ocupada",
+  reserved: "Reservada"
 };
 
 const Tables = () => {
@@ -69,7 +69,7 @@ const Tables = () => {
         console.error("Error fetching tables:", error);
         toast({
           title: "Error",
-          description: "Failed to load tables. Please try again.",
+          description: "No se pudieron cargar las mesas. Inténtalo de nuevo.",
           variant: "destructive",
         });
       } finally {
@@ -110,8 +110,8 @@ const Tables = () => {
   return (
     <MainLayout>
       <div className="container mx-auto py-6">
-        <PageHeader 
-          title="Table Selection" 
+        <PageHeader
+          title="Selección de Mesa"
           className="mb-4"
         />
         
@@ -135,7 +135,7 @@ const Tables = () => {
                   <CardContent className="flex flex-col items-center justify-center p-6 h-24">
                     <span className="text-2xl font-bold">{table.number}</span>
                     <span className="text-sm mt-1">{statusLabels[table.status]}</span>
-                    <span className="text-xs text-muted-foreground">Capacity: {table.capacity}</span>
+                    <span className="text-xs text-muted-foreground">Capacidad: {table.capacity}</span>
                   </CardContent>
                 </Card>
               );
@@ -146,7 +146,7 @@ const Tables = () => {
         <Dialog open={showClientDialog} onOpenChange={setShowClientDialog}>
           <DialogContent className="sm:max-w-md">
             <DialogHeader>
-              <DialogTitle>Select Number of Clients for Table {selectedTable}</DialogTitle>
+              <DialogTitle>Selecciona número de clientes para la mesa {selectedTable}</DialogTitle>
             </DialogHeader>
             <div className="py-4">
               <div className="grid grid-cols-3 gap-2">
@@ -164,10 +164,10 @@ const Tables = () => {
             </div>
             <DialogFooter>
               <Button onClick={() => setShowClientDialog(false)} variant="outline">
-                Cancel
+                Cancelar
               </Button>
               <Button onClick={handleClientSelection}>
-                Confirm
+                Confirmar
               </Button>
             </DialogFooter>
           </DialogContent>


### PR DESCRIPTION
## Summary
- translate table labels and dialog text to Spanish
- update menu and inventory pages with Spanish interface text
- localize employee actions to Spanish
- update category and subcategory dialogs with Spanish text

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68676180202c8321b867f73253dbb5d6