### PR TITLE
Frontend staff form integration

### DIFF
--- a/frontend/src/components/employees/AddEmployeeForm.tsx
+++ b/frontend/src/components/employees/AddEmployeeForm.tsx
@@ -1,0 +1,182 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+
+import { useToast } from "@/hooks/use-toast";
+import { useLanguage } from "@/context/LanguageContext";
+import { createEmployee } from "@/services/api";
+
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const formSchema = z.object({
+  nombre: z.string().min(1, { message: "Requerido" }),
+  cargo: z.string().min(1, { message: "Requerido" }),
+  estado: z.enum(["active", "off"]).default("active"),
+  horarioEntrada: z.string().optional(),
+  horasTrabajadas: z.string().optional(),
+  descanso: z.boolean().optional(),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface AddEmployeeFormProps {
+  onSuccess?: () => void;
+}
+
+const AddEmployeeForm: React.FC<AddEmployeeFormProps> = ({ onSuccess }) => {
+  const { toast } = useToast();
+  const { t } = useLanguage();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      nombre: "",
+      cargo: "",
+      estado: "active",
+      horarioEntrada: "",
+      horasTrabajadas: "",
+      descanso: false,
+    },
+  });
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      await createEmployee({
+        name: values.nombre,
+        position: values.cargo,
+        status: values.estado,
+        hourly_rate: values.horasTrabajadas
+          ? parseFloat(values.horasTrabajadas)
+          : undefined,
+        clock_in: values.horarioEntrada || undefined,
+        break_start: values.descanso ? new Date().toISOString() : undefined,
+      });
+      toast({ title: t("Empleado guardado") });
+      form.reset();
+      if (onSuccess) onSuccess();
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: t("Error"),
+        description: t("No se pudo guardar el empleado"),
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="nombre"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("Nombre")}</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="cargo"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("Cargo")}</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="estado"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("Estado")}</FormLabel>
+              <Select onValueChange={field.onChange} value={field.value}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="active">{t("Activo")}</SelectItem>
+                  <SelectItem value="off">{t("Inactivo")}</SelectItem>
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="horarioEntrada"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("Horario de entrada")}</FormLabel>
+              <FormControl>
+                <Input type="time" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="horasTrabajadas"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("Horas trabajadas")}</FormLabel>
+              <FormControl>
+                <Input type="number" step="0.1" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="descanso"
+          render={({ field }) => (
+            <FormItem className="flex items-center gap-2">
+              <FormControl>
+                <Checkbox
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                />
+              </FormControl>
+              <FormLabel className="m-0">{t("Descanso")}</FormLabel>
+            </FormItem>
+          )}
+        />
+        <Button type="submit">{t("Guardar Empleado")}</Button>
+      </form>
+    </Form>
+  );
+};
+
+export default AddEmployeeForm;

--- a/frontend/src/pages/Employees.tsx
+++ b/frontend/src/pages/Employees.tsx
@@ -9,8 +9,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
 import { useLanguage } from "@/context/LanguageContext";
 import { getEmployees, updateEmployeeStatus, addBreakRecord, updateBreakRecord, Employee } from "@/services/employee.service";
-import { Plus, Pencil } from "lucide-react";
-import AddEmployeeDialog from "@/components/employees/AddEmployeeDialog";
+import { Pencil } from "lucide-react";
 import EditEmployeeDialog from "@/components/employees/EditEmployeeDialog";
 import BreakTimeTracker from "@/components/employees/BreakTimeTracker";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -377,7 +376,6 @@ const TimeSheet = () => {
 
 const Employees = () => {
   const { t } = useLanguage();
-  const [addEmployeeOpen, setAddEmployeeOpen] = useState(false);
   const [editEmployee, setEditEmployee] = useState<Employee | null>(null);
   const [editEmployeeOpen, setEditEmployeeOpen] = useState(false);
   const queryClient = useQueryClient();
@@ -393,11 +391,6 @@ const Employees = () => {
       <div className="max-w-5xl mx-auto">
         <div className="flex justify-between items-center mb-6">
           <h1 className="text-3xl font-bold">{t("Gestión de Empleados")}</h1>
-
-          <Button onClick={() => setAddEmployeeOpen(true)}>
-            <Plus className="mr-2 h-4 w-4" />
-            {t("Agregar Empleado")}
-          </Button>
         </div>
         
         {isLoading ? (
@@ -426,11 +419,6 @@ const Employees = () => {
           </Tabs>
         )}
         
-        <AddEmployeeDialog 
-          open={addEmployeeOpen} 
-          onOpenChange={setAddEmployeeOpen} 
-          onSuccess={() => queryClient.invalidateQueries({ queryKey: ["employees"] })}
-        />
 
         <EditEmployeeDialog
           employee={editEmployee}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -5,7 +5,8 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PageHeader } from "@/components/ui/page-header";
-import { Settings as SettingsIcon, Building, CreditCard, Users, Bell, Map, Printer, Languages, Database } from "lucide-react";
+import { Settings as SettingsIcon, Users, Bell, Map } from "lucide-react";
+import AddEmployeeForm from "@/components/employees/AddEmployeeForm";
 import { TableMapEditor } from "@/components/TableMap/TableMapEditor";
 import { useLanguage } from "@/context/LanguageContext";
 
@@ -54,7 +55,7 @@ const TableLayoutSection = () => {
 
 const Settings = () => {
   const { t } = useLanguage();
-  const [activeTab, setActiveTab] = React.useState("restaurant");
+  const [activeTab, setActiveTab] = React.useState("tables");
 
   return (
     <MainLayout>
@@ -69,17 +70,9 @@ const Settings = () => {
         <Tabs value={activeTab} onValueChange={setActiveTab}>
           <div className="overflow-auto scrollbar-none pb-2">
             <TabsList className="mb-8">
-              <TabsTrigger value="restaurant" className="flex items-center gap-2">
-                <Building className="h-4 w-4" />
-                <span>{t("Restaurante")}</span>
-              </TabsTrigger>
               <TabsTrigger value="tables" className="flex items-center gap-2">
                 <Map className="h-4 w-4" />
                 <span>{t("Mesas")}</span>
-              </TabsTrigger>
-              <TabsTrigger value="payment" className="flex items-center gap-2">
-                <CreditCard className="h-4 w-4" />
-                <span>{t("Pagos")}</span>
               </TabsTrigger>
               <TabsTrigger value="staff" className="flex items-center gap-2">
                 <Users className="h-4 w-4" />
@@ -89,18 +82,6 @@ const Settings = () => {
                 <Bell className="h-4 w-4" />
                 <span>{t("Notificaciones")}</span>
               </TabsTrigger>
-              <TabsTrigger value="printers" className="flex items-center gap-2">
-                <Printer className="h-4 w-4" />
-                <span>{t("Impresoras")}</span>
-              </TabsTrigger>
-              <TabsTrigger value="language" className="flex items-center gap-2">
-                <Languages className="h-4 w-4" />
-                <span>{t("Idioma")}</span>
-              </TabsTrigger>
-              <TabsTrigger value="system" className="flex items-center gap-2">
-                <Database className="h-4 w-4" />
-                <span>{t("Sistema")}</span>
-              </TabsTrigger>
             </TabsList>
           </div>
 
@@ -109,58 +90,8 @@ const Settings = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.3 }}
           >
-            <TabsContent value="restaurant">
-              <div className="space-y-6">
-                <Card>
-                  <CardHeader>
-                    <CardTitle>{t("Información del Restaurante")}</CardTitle>
-                    <CardDescription>
-                      {t("Actualiza la información básica de tu restaurante")}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-sm text-muted-foreground">
-                      {t("Aquí podrás ingresar nombre, dirección y datos de contacto del restaurante")}
-                    </p>
-                  </CardContent>
-                </Card>
-
-                <Card>
-                  <CardHeader>
-                    <CardTitle>{t("Horarios de Atención")}</CardTitle>
-                    <CardDescription>
-                      {t("Define los horarios de operación del restaurante")}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-sm text-muted-foreground">
-                      {t("Incluye horarios de operación, días festivos y horarios especiales")}
-                    </p>
-                  </CardContent>
-                </Card>
-              </div>
-            </TabsContent>
-
             <TabsContent value="tables">
               <TableLayoutSection />
-            </TabsContent>
-
-            <TabsContent value="payment">
-              <div className="space-y-6">
-                <Card>
-                  <CardHeader>
-                    <CardTitle>{t("Métodos de Pago")}</CardTitle>
-                    <CardDescription>
-                      {t("Configura los métodos de pago aceptados")}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-sm text-muted-foreground">
-                      {t("Contendrá integraciones de pago y configuraciones de caja")}
-                    </p>
-                  </CardContent>
-                </Card>
-              </div>
             </TabsContent>
 
             <TabsContent value="staff">
@@ -172,10 +103,11 @@ const Settings = () => {
                       {t("Administra a tus empleados y permisos")}
                     </CardDescription>
                   </CardHeader>
-                  <CardContent>
+                  <CardContent className="space-y-4">
                     <p className="text-sm text-muted-foreground">
                       {t("Aquí podrás gestionar usuarios, roles y permisos")}
                     </p>
+                    <AddEmployeeForm />
                   </CardContent>
                 </Card>
               </div>
@@ -199,59 +131,6 @@ const Settings = () => {
               </div>
             </TabsContent>
 
-            <TabsContent value="printers">
-              <div className="space-y-6">
-                <Card>
-                  <CardHeader>
-                    <CardTitle>{t("Configuración de Impresoras")}</CardTitle>
-                    <CardDescription>
-                      {t("Configura impresoras de recibos y cocina")}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-sm text-muted-foreground">
-                      {t("Conexiones de impresoras, plantillas y ajustes")}
-                    </p>
-                  </CardContent>
-                </Card>
-              </div>
-            </TabsContent>
-
-            <TabsContent value="language">
-              <div className="space-y-6">
-                <Card>
-                  <CardHeader>
-                    <CardTitle>{t("Idioma y Región")}</CardTitle>
-                    <CardDescription>
-                      {t("Configura el idioma y preferencias regionales")}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-sm text-muted-foreground">
-                      {t("Selecciona idioma, formatos de fecha y moneda")}
-                    </p>
-                  </CardContent>
-                </Card>
-              </div>
-            </TabsContent>
-
-            <TabsContent value="system">
-              <div className="space-y-6">
-                <Card>
-                  <CardHeader>
-                    <CardTitle>{t("Información del Sistema")}</CardTitle>
-                    <CardDescription>
-                      {t("Consulta detalles del sistema y realiza mantenimiento")}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-sm text-muted-foreground">
-                      {t("Información del sistema, opciones de respaldo y herramientas de mantenimiento")}
-                    </p>
-                  </CardContent>
-                </Card>
-              </div>
-            </TabsContent>
           </motion.div>
         </Tabs>
       </div>


### PR DESCRIPTION
## Summary
- remove "Agregar Empleado" button from employees page
- trim settings page to only keep Mesas, Personal and Notificaciones tabs
- embed new AddEmployeeForm in the Personal tab
- implement `AddEmployeeForm` component

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68696abbb9988321958f3e5b628612a3